### PR TITLE
#162067471- API endpoint for getting all red-flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.nyc_output

--- a/server/app.js
+++ b/server/app.js
@@ -1,5 +1,6 @@
 /* eslint no-console: "off" */
 import express from 'express';
+import router from './routes';
 
 const app = express();
 
@@ -14,6 +15,8 @@ app.get('/', (req, res) => {
     message: 'Welcome to home page',
   });
 });
+
+app.use('/api/v1', router);
 
 app.use('*', (err, req, res, next) => {
   const statusCode = err.statusCode || 500;

--- a/server/controllers/redFlag.js
+++ b/server/controllers/redFlag.js
@@ -1,0 +1,24 @@
+import incidents from '../datastore/incident';
+/** incident controller class */
+
+class redFlagController {
+  /**
+ * @function getRedFlags
+ * @memberof incidentController
+ * @static
+ */
+  static getRedFlags(req, res) {
+    const redFlags = [];
+    incidents.forEach((redFlag) => {
+      if (redFlag.type === 'red-flag') {
+        redFlags.push(redFlag);
+      }
+    });
+    return res.status(200).json({
+      status: 200,
+      success: 'true',
+      data: redFlags,
+    });
+  }
+}
+export default redFlagController;

--- a/server/datastore/incident.js
+++ b/server/datastore/incident.js
@@ -1,9 +1,9 @@
 /**
- * a list of all red-flags
+ * a list of all red-flags and incidents
  * @constant
  *
  * @type {Array<Object>}
- * @exports allOrders
+ * @exports incidents
  */
 const incidents = [
   {
@@ -26,7 +26,18 @@ const incidents = [
     status: 'draft',
     Images: ['www.image.com', 'www.image.com'],
     Videos: ['www.video.com', 'www.video.com'],
-    comment: 'There is a broken bridge betweem Ota and Abeokut',
+    comment: 'There is a broken bridge betweem Ota and Abeokuta',
+  },
+  {
+    id: 3,
+    createdOn: new Date().toISOString(),
+    createdBy: 1,
+    type: 'red-flag',
+    location: '6.4828617, 3.1896830',
+    status: 'draft',
+    Images: ['www.image.com', 'www.image.com'],
+    Videos: ['www.video.com', 'www.video.com'],
+    comment: 'There is a broken bridge betweem Ota and Badagry',
   },
 ];
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import redFlagController from '../controllers/redFlag';
+
+const router = express.Router();
+
+router.route('/red-flags')
+  .get(redFlagController.getRedFlags);
+
+export default router;

--- a/server/test/app.spec.js
+++ b/server/test/app.spec.js
@@ -1,0 +1,28 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+
+import app from '../app';
+import express from 'express';
+
+chai.use(chaiHttp);
+
+describe('app test', () => {
+  it('has a module called app', (done) => {
+    expect(app).to.be.ok;
+    done();
+  });
+
+  it('should respond with a welcome message', (done) => {
+    chai.request(app)
+      .get('/')
+      .end((err, res) => {
+        expect(err).to.not.exist;
+        expect(res.status).to.equal(200);
+        expect(res.body.success).to.equal('true');
+        expect(res.type).to.equal('application/json');
+        expect(res.body).to.be.an('object');
+        expect(res.body.message).to.equal('Welcome to home page');
+        done();
+      });
+  });
+});

--- a/server/test/getAllRedFlags.spec.js
+++ b/server/test/getAllRedFlags.spec.js
@@ -1,0 +1,24 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import incidents from '../datastore/incident';
+
+chai.use(chaiHttp);
+
+describe('redflag controller status', () => {
+  describe('/GET all red-flags', () => {
+    it('should get all red-flags', (done) => {
+      chai.request(app)
+        .get('/api/v1/red-flags/')
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('true');
+          expect(res.body.status).to.equal(200);
+          expect(res.body.data).to.be.an('array');
+          done();
+        });
+    });
+  })
+})

--- a/server/test/index.spec.js
+++ b/server/test/index.spec.js
@@ -1,0 +1,2 @@
+import './app.spec';
+import './getAllRedFlags.spec';


### PR DESCRIPTION
**What does this PR do?**
This is a pull request for the API endpoint to get all red-flag incidents. 

**Description of Task to be completed?**
Have the following endpoint working and tested on postman:
`GET /api/v1/red-flags/`

**How should this be manually tested?**
- Clone the repo using git clone` https://github.com/fejiroofficial/iReporter.git.`
- run `git checkout ft-get-all-redflags`
- run `npm install` and `npm start`.
- `to run the test: npm run test`
- `test using postman`
![screenshot 280](https://user-images.githubusercontent.com/38490848/48735503-d9c27380-ec48-11e8-8a26-b60ab376a841.png)


**Relevant pivotal stories**
[162067471](https://www.pivotaltracker.com/n/projects/2226593/stories/162067471)