### PR TITLE
#162099319- API endpoint required to edit red-flag location

### DIFF
--- a/server/controllers/redFlag.js
+++ b/server/controllers/redFlag.js
@@ -1,6 +1,7 @@
 /* eslint linebreak-style: "off" */
 /* eslint no-plusplus: "off" */
 /* eslint no-restricted-globals: "off" */
+/* eslint no-param-reassign: "off" */
 
 import incidents from '../datastore/incident';
 import users from '../datastore/users';
@@ -132,6 +133,59 @@ class redFlagController {
       }
     }
     return incidents;
+  }
+
+  /**
+ * @function updateLocation
+ * @memberof redFlagController
+ * @static
+ */
+  static updateLocation(req, res) {
+    const redFlagId = parseInt(req.params.id, 10);
+    const redFlags = [];
+    const data = [];
+    const dataObject = {};
+    let { location } = req.body;
+    location = location && location
+      .toLowerCase().toString().trim().replace(/\s+/g, ' ');
+    if (isNaN(redFlagId)) {
+      return res.status(400).json({
+        success: 'false',
+        message: 'hooops! params should be a number e.g 1',
+      });
+    }
+    incidents.forEach((incident) => {
+      if (incident.type === 'red-flag') {
+        redFlags.push(incident);
+      }
+    });
+    if (redFlags.length === 0) {
+      return res.status(404).json({
+        status: 404,
+        success: 'false',
+        message: 'No red-flag record found',
+      });
+    }
+    redFlags.forEach((redFlag) => {
+      if (redFlag.id === redFlagId) {
+        redFlag.location = location;
+        dataObject.id = redFlag.id;
+        dataObject.message = 'Updated red-flag record’s location';
+      }
+    });
+    if (Object.keys(dataObject).length === 0) {
+      return res.status(404).json({
+        status: 404,
+        success: 'false',
+        message: 'This red-flag record does not exist',
+      });
+    }
+    data.push(dataObject);
+    return res.status(201).json({
+      status: 201,
+      success: 'true',
+      data,
+    });
   }
 }
 export default redFlagController;

--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -1,7 +1,11 @@
+/* eslint linebreak-style: "off" */
+
 import validatePostRedFlag from './validatePostRedFlag';
+import validateUpdateLocation from './validateUpdateLocation';
 
 const middlewares = {
   validatePostRedFlag,
+  validateUpdateLocation,
 };
 
 export default middlewares;

--- a/server/middlewares/validatePostRedFlag.js
+++ b/server/middlewares/validatePostRedFlag.js
@@ -1,3 +1,5 @@
+/* eslint linebreak-style: "off" */
+
 /**
  * This is a validation for post red-flag
  * @constant
@@ -59,7 +61,7 @@ const validatePostRedFlag = (req, res, next) => {
     return next(err);
   }
 
-  if (type !== 'red-flag' && type !== 'intervention') {
+  if (type.toLowerCase() !== 'red-flag' && type.toLowerCase() !== 'intervention') {
     const err = new Error('Incidents can only be \'red-flag\' or \'intervention\'');
     err.statusCode = 400;
     return next(err);

--- a/server/middlewares/validateUpdateLocation.js
+++ b/server/middlewares/validateUpdateLocation.js
@@ -1,0 +1,26 @@
+/* eslint linebreak-style: "off" */
+
+/**
+ * This is a validation for updating red-flag location
+ * @constant
+ * 
+ * @param {String} req request object
+ * @param {Object} res response object
+ * @param {Object} err error object
+ * 
+ * @returns {Object}
+ *
+ * @exports validateUpdateLocation
+ */
+
+const validateUpdateLocation = (req, res, next) => {
+  const { location } = req.body;
+
+  if (!location) {
+    const err = new Error('Please provide the location for this red-flag incident');
+    err.statusCode = 400;
+    return next(err);
+  }
+  return next();
+};
+export default validateUpdateLocation;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -11,5 +11,6 @@ router.route('/red-flags')
   .post(middlewares.validatePostRedFlag, redFlagController.postRedFlag);
 router.route('/red-flags/:id')
   .get(redFlagController.getRedFlag);
+router.patch('/red-flags/:id/location', middlewares.validateUpdateLocation, redFlagController.updateLocation);
 
 export default router;

--- a/server/test/redFlags.spec.js
+++ b/server/test/redFlags.spec.js
@@ -251,4 +251,71 @@ describe('redflag controller status', () => {
         });
     });
   })
+
+  describe('/PATCH red-flag location', () => {  
+    it('should throw an error if location is not provided', (done) => {
+      chai.request(app)
+        .patch('/api/v1/red-flags/:id/location')
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('Please provide the location for this red-flag incident');
+          done();
+        });
+    });
+
+    it('throw error if param is not an integer', (done) => {
+      const requestBody = {
+        location: '6.4828617, 3.1896830',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/b/location')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('hooops! params should be a number e.g 1');
+          done();
+        });
+    });
+
+    it('throw error if red-flag does not exist', (done) => {
+      const requestBody = {
+        location: '6.4828617, 3.1896830',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/100/location')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(404);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('This red-flag record does not exist');
+          done();
+        });
+    });
+
+    it('return success if red-flag record is found', (done) => {
+      const requestBody = {
+        location: '6.4828617, 3.1896830',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/1/location')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(201);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.status).to.equal(201);
+          expect(res.body.success).to.equal('true');
+          expect(res.body.data[0].message).to.equal('Updated red-flag record’s location');
+          done();
+        });
+    });
+  })
 })


### PR DESCRIPTION
**What does this PR do?**
This is a pull request for the API endpoint to edit a red-flags location. 

**Description of Task to be completed?**
Have the following endpoint working and tested on postman:
`PATCH /api/v1/red-flags/<red-flag-id>/location`

**How should this be manually tested?**
- Clone the repo using git clone` https://github.com/fejiroofficial/iReporter.git.`
- run `git checkout ft-update-location-162099319`
- run `npm install` and `npm start`.
- `to run the test: npm run test`
- `test using postman`
![screenshot 286](https://user-images.githubusercontent.com/38490848/48836475-290cbf00-ed83-11e8-840d-d100ceed1c46.png)

**Relevant pivotal stories**
[162099319](https://www.pivotaltracker.com/n/projects/2226593/stories/162099319)