### PR TITLE
#162104409- API endpoint required to edit a red-flag comment

### DIFF
--- a/server/controllers/redFlag.js
+++ b/server/controllers/redFlag.js
@@ -187,5 +187,58 @@ class redFlagController {
       data,
     });
   }
+
+  /**
+* @function updateComment
+* @memberof redFlagController
+* @static
+*/
+  static updateComment(req, res) {
+    const redFlagId = parseInt(req.params.id, 10);
+    const redFlags = [];
+    const data = [];
+    const dataObject = {};
+    let { comment } = req.body;
+    comment = comment && comment
+      .toLowerCase().toString().trim().replace(/\s+/g, ' ');
+    if (isNaN(redFlagId)) {
+      return res.status(400).json({
+        success: 'false',
+        message: 'hooops! params should be a number e.g 1',
+      });
+    }
+    incidents.forEach((incident) => {
+      if (incident.type === 'red-flag') {
+        redFlags.push(incident);
+      }
+    });
+    if (redFlags.length === 0) {
+      return res.status(404).json({
+        status: 404,
+        success: 'false',
+        message: 'No red-flag record found',
+      });
+    }
+    redFlags.forEach((redFlag) => {
+      if (redFlag.id === redFlagId) {
+        redFlag.comment = comment;
+        dataObject.id = redFlag.id;
+        dataObject.message = 'Updated red-flag record’s comment';
+      }
+    });
+    if (Object.keys(dataObject).length === 0) {
+      return res.status(404).json({
+        status: 404,
+        success: 'false',
+        message: 'This red-flag record does not exist',
+      });
+    }
+    data.push(dataObject);
+    return res.status(201).json({
+      status: 201,
+      success: 'true',
+      data,
+    });
+  }
 }
 export default redFlagController;

--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -2,10 +2,12 @@
 
 import validatePostRedFlag from './validatePostRedFlag';
 import validateUpdateLocation from './validateUpdateLocation';
+import validateUpdateComment from './validateUpdateComment';
 
 const middlewares = {
   validatePostRedFlag,
   validateUpdateLocation,
+  validateUpdateComment,
 };
 
 export default middlewares;

--- a/server/middlewares/validateUpdateComment.js
+++ b/server/middlewares/validateUpdateComment.js
@@ -1,0 +1,27 @@
+/* eslint linebreak-style: "off" */
+
+/**
+ * This is a validation for updating red-flag comment
+ * @constant
+ * 
+ * @param {String} req request object
+ * @param {Object} res response object
+ * @param {Object} err error object
+ * 
+ * @returns {Object}
+ *
+ * @exports validateUpdateComment
+ */
+
+const validateUpdateComment = (req, res, next) => {
+  let { comment } = req.body;
+  comment = comment && comment.toString().trim();
+
+  if (!comment) {
+    const err = new Error('Please provide a brief comment for this red-flag incident');
+    err.statusCode = 400;
+    return next(err);
+  }
+  return next();
+};
+export default validateUpdateComment;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -12,5 +12,6 @@ router.route('/red-flags')
 router.route('/red-flags/:id')
   .get(redFlagController.getRedFlag);
 router.patch('/red-flags/:id/location', middlewares.validateUpdateLocation, redFlagController.updateLocation);
+router.patch('/red-flags/:id/comment', middlewares.validateUpdateComment, redFlagController.updateComment);
 
 export default router;

--- a/server/test/redFlags.spec.js
+++ b/server/test/redFlags.spec.js
@@ -255,7 +255,7 @@ describe('redflag controller status', () => {
   describe('/PATCH red-flag location', () => {  
     it('should throw an error if location is not provided', (done) => {
       chai.request(app)
-        .patch('/api/v1/red-flags/:id/location')
+        .patch('/api/v1/red-flags/1/location')
         .end((err, res) => {
           expect(res.status).to.equal(400);
           expect(res.type).to.equal('application/json');
@@ -314,6 +314,73 @@ describe('redflag controller status', () => {
           expect(res.body.status).to.equal(201);
           expect(res.body.success).to.equal('true');
           expect(res.body.data[0].message).to.equal('Updated red-flag record’s location');
+          done();
+        });
+    });
+  })
+
+  describe('/PATCH red-flag comment', () => {  
+    it('should throw an error if comment is not provided', (done) => {
+      chai.request(app)
+        .patch('/api/v1/red-flags/1/comment')
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('Please provide a brief comment for this red-flag incident');
+          done();
+        });
+    });
+
+    it('throw error if param is not an integer', (done) => {
+      const requestBody = {
+        comment: 'this is a brief comment',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/b/comment')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('hooops! params should be a number e.g 1');
+          done();
+        });
+    });
+
+    it('throw error if red-flag does not exist', (done) => {
+      const requestBody = {
+        comment: 'this is a brief comment',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/100/comment')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(404);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('This red-flag record does not exist');
+          done();
+        });
+    });
+
+    it('return success if red-flag record is found', (done) => {
+      const requestBody = {
+        comment: 'this is a brief comment',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/1/comment')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(201);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.status).to.equal(201);
+          expect(res.body.success).to.equal('true');
+          expect(res.body.data[0].message).to.equal('Updated red-flag record’s comment');
           done();
         });
     });


### PR DESCRIPTION
**What does this PR do?**
This is a pull request for the API endpoint to edit a red-flags comment. 

**Description of Task to be completed?**
Have the following endpoint working and tested on postman:
`PATCH /api/v1/red-flags/<red-flag-id>/comment`

**How should this be manually tested?**
- Clone the repo using git clone` https://github.com/fejiroofficial/iReporter.git.`
- run `git checkout ft-update-comment-162104409`
- run `npm install` and `npm start`.
- `to run the test: npm run test`
- `test using postman`
![screenshot 287](https://user-images.githubusercontent.com/38490848/48840320-8ce8b500-ed8e-11e8-93c3-c72e2c26e705.png)

**Relevant pivotal stories**
[162104409](https://www.pivotaltracker.com/n/projects/2226593/stories/162104409)