### PR TITLE
#162105836- API endpoint required to a delete red-flag record

### DIFF
--- a/server/controllers/redFlag.js
+++ b/server/controllers/redFlag.js
@@ -142,6 +142,7 @@ class redFlagController {
  */
   static updateLocation(req, res) {
     const redFlagId = parseInt(req.params.id, 10);
+    const userId = parseInt(req.body.userId, 10);
     const redFlags = [];
     const data = [];
     const dataObject = {};
@@ -167,17 +168,18 @@ class redFlagController {
       });
     }
     redFlags.forEach((redFlag) => {
-      if (redFlag.id === redFlagId) {
+      if (redFlag.id === redFlagId && redFlag.createdBy === userId) {
         redFlag.location = location;
         dataObject.id = redFlag.id;
+        dataObject.updatedBy = redFlag.createdBy;
         dataObject.message = 'Updated red-flag record’s location';
       }
     });
     if (Object.keys(dataObject).length === 0) {
-      return res.status(404).json({
-        status: 404,
+      return res.status(400).json({
+        status: 400,
         success: 'false',
-        message: 'This red-flag record does not exist',
+        message: 'This red-flag record either does not exist or does not belong to you',
       });
     }
     data.push(dataObject);
@@ -195,6 +197,7 @@ class redFlagController {
 */
   static updateComment(req, res) {
     const redFlagId = parseInt(req.params.id, 10);
+    const userId = parseInt(req.body.userId, 10);
     const redFlags = [];
     const data = [];
     const dataObject = {};
@@ -220,17 +223,18 @@ class redFlagController {
       });
     }
     redFlags.forEach((redFlag) => {
-      if (redFlag.id === redFlagId) {
+      if (redFlag.id === redFlagId && redFlag.createdBy === userId) {
         redFlag.comment = comment;
         dataObject.id = redFlag.id;
+        dataObject.updatedBy = redFlag.createdBy;
         dataObject.message = 'Updated red-flag record’s comment';
       }
     });
     if (Object.keys(dataObject).length === 0) {
-      return res.status(404).json({
-        status: 404,
+      return res.status(400).json({
+        status: 400,
         success: 'false',
-        message: 'This red-flag record does not exist',
+        message: 'This red-flag record either does not exist or does not belong to you',
       });
     }
     data.push(dataObject);
@@ -240,5 +244,70 @@ class redFlagController {
       data,
     });
   }
+
+  /**
+ * @function deleteRedFlag
+ * @memberof redFlagController
+ * @static
+ */
+  static deleteRedFlag(req, res) {
+    const redFlagId = parseInt(req.params.id, 10);
+    const userId = parseInt(req.body.userId, 10);
+    const redFlags = [];
+    const data = [];
+    const dataObject = {};
+    if (!userId || isNaN(userId)) {
+      return res.status(401).json({
+        success: 'false',
+        message: 'unauthorized user, please provide a valid user id',
+      });
+    }
+
+    if (isNaN(redFlagId)) {
+      return res.status(400).json({
+        success: 'false',
+        message: 'hooops! params should be a number e.g 1',
+      });
+    }
+
+    incidents.forEach((incident) => {
+      if (incident.type === 'red-flag') {
+        redFlags.push(incident);
+      }
+    });
+
+    if (redFlags.length === 0) {
+      return res.status(404).json({
+        status: 404,
+        success: 'false',
+        message: 'No red-flag record found',
+      });
+    }
+
+    redFlags.forEach((redFlag) => {
+      if (redFlag.id === redFlagId && redFlag.createdBy === userId) {
+        const redFlagindex = redFlags.indexOf(redFlag);
+        redFlags.splice(redFlagindex, 1);
+        dataObject.id = redFlag.id;
+        dataObject.deletedBy = redFlag.createdBy;
+        dataObject.message = 'red-flag record has been deleted';
+      }
+    });
+
+    if (Object.keys(dataObject).length === 0) {
+      return res.status(400).json({
+        status: 400,
+        success: 'false',
+        message: 'This red-flag record either does not exist or does not belong to you',
+      });
+    }
+    data.push(dataObject);
+    return res.status(200).json({
+      status: 200,
+      success: 'true',
+      data,
+    });
+  }
 }
+
 export default redFlagController;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -9,8 +9,11 @@ const router = express.Router();
 router.route('/red-flags')
   .get(redFlagController.getRedFlags)
   .post(middlewares.validatePostRedFlag, redFlagController.postRedFlag);
+
 router.route('/red-flags/:id')
-  .get(redFlagController.getRedFlag);
+  .get(redFlagController.getRedFlag)
+  .delete(redFlagController.deleteRedFlag);
+
 router.patch('/red-flags/:id/location', middlewares.validateUpdateLocation, redFlagController.updateLocation);
 router.patch('/red-flags/:id/comment', middlewares.validateUpdateComment, redFlagController.updateComment);
 

--- a/server/test/redFlags.spec.js
+++ b/server/test/redFlags.spec.js
@@ -291,17 +291,18 @@ describe('redflag controller status', () => {
         .patch('/api/v1/red-flags/100/location')
         .send(requestBody)
         .end((err, res) => {
-          expect(res.status).to.equal(404);
+          expect(res.status).to.equal(400);
           expect(res.type).to.equal('application/json');
           expect(res.body).to.be.an('object');
           expect(res.body.success).to.equal('false');
-          expect(res.body.message).to.equal('This red-flag record does not exist');
+          expect(res.body.message).to.equal('This red-flag record either does not exist or does not belong to you');
           done();
         });
     });
 
     it('return success if red-flag record is found', (done) => {
       const requestBody = {
+        userId: 1,
         location: '6.4828617, 3.1896830',
       };
       chai.request(app)
@@ -358,17 +359,18 @@ describe('redflag controller status', () => {
         .patch('/api/v1/red-flags/100/comment')
         .send(requestBody)
         .end((err, res) => {
-          expect(res.status).to.equal(404);
+          expect(res.status).to.equal(400);
           expect(res.type).to.equal('application/json');
           expect(res.body).to.be.an('object');
           expect(res.body.success).to.equal('false');
-          expect(res.body.message).to.equal('This red-flag record does not exist');
+          expect(res.body.message).to.equal('This red-flag record either does not exist or does not belong to you');
           done();
         });
     });
 
     it('return success if red-flag record is found', (done) => {
       const requestBody = {
+        userId: 1,
         comment: 'this is a brief comment',
       };
       chai.request(app)
@@ -381,6 +383,209 @@ describe('redflag controller status', () => {
           expect(res.body.status).to.equal(201);
           expect(res.body.success).to.equal('true');
           expect(res.body.data[0].message).to.equal('Updated red-flag record’s comment');
+          done();
+        });
+    });
+  })
+
+   describe('/PATCH red-flag location', () => {  
+    it('should throw an error if location is not provided', (done) => {
+      chai.request(app)
+        .patch('/api/v1/red-flags/1/location')
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('Please provide the location for this red-flag incident');
+          done();
+        });
+    });
+
+    it('throw error if param is not an integer', (done) => {
+      const requestBody = {
+        location: '6.4828617, 3.1896830',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/b/location')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('hooops! params should be a number e.g 1');
+          done();
+        });
+    });
+
+    it('throw error if red-flag does not exist', (done) => {
+      const requestBody = {
+        location: '6.4828617, 3.1896830',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/100/location')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('This red-flag record either does not exist or does not belong to you');
+          done();
+        });
+    });
+
+    it('return success if red-flag record is found', (done) => {
+      const requestBody = {
+        userId: 1,
+        location: '6.4828617, 3.1896830',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/1/location')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(201);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.status).to.equal(201);
+          expect(res.body.success).to.equal('true');
+          expect(res.body.data[0].message).to.equal('Updated red-flag record’s location');
+          done();
+        });
+    });
+  })
+
+  describe('/PATCH red-flag comment', () => {  
+    it('should throw an error if comment is not provided', (done) => {
+      chai.request(app)
+        .patch('/api/v1/red-flags/1/comment')
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('Please provide a brief comment for this red-flag incident');
+          done();
+        });
+    });
+
+    it('throw error if param is not an integer', (done) => {
+      const requestBody = {
+        comment: 'this is a brief comment',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/b/comment')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('hooops! params should be a number e.g 1');
+          done();
+        });
+    });
+
+    it('throw error if red-flag does not exist', (done) => {
+      const requestBody = {
+        comment: 'this is a brief comment',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/100/comment')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('This red-flag record either does not exist or does not belong to you');
+          done();
+        });
+    });
+
+    it('return success if red-flag record is found', (done) => {
+      const requestBody = {
+        userId: 1,
+        comment: 'this is a brief comment',
+      };
+      chai.request(app)
+        .patch('/api/v1/red-flags/1/comment')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(201);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.status).to.equal(201);
+          expect(res.body.success).to.equal('true');
+          expect(res.body.data[0].message).to.equal('Updated red-flag record’s comment');
+          done();
+        });
+    });
+  })
+
+  describe('/DELETE red-flag comment', () => {  
+    it('should throw an error if comment is not provided', (done) => {
+      chai.request(app)
+        .delete('/api/v1/red-flags/1/')
+        .end((err, res) => {
+          expect(res.status).to.equal(401);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('unauthorized user, please provide a valid user id');
+          done();
+        });
+    });
+
+    it('throw error if param is not an integer', (done) => {
+      const requestBody = {
+        userId: 1,
+      };
+      chai.request(app)
+        .delete('/api/v1/red-flags/b')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('hooops! params should be a number e.g 1');
+          done();
+        });
+    });
+
+    it('throw error if red-flag does not exist', (done) => {
+      const requestBody = {
+        userId: 1,
+      };
+      chai.request(app)
+        .delete('/api/v1/red-flags/100')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.success).to.equal('false');
+          expect(res.body.message).to.equal('This red-flag record either does not exist or does not belong to you');
+          done();
+        });
+    });
+
+    it('return success if red-flag record is deleted', (done) => {
+      const requestBody = {
+        userId: 1,
+      };
+      chai.request(app)
+        .delete('/api/v1/red-flags/1')
+        .send(requestBody)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.type).to.equal('application/json');
+          expect(res.body).to.be.an('object');
+          expect(res.body.status).to.equal(200);
+          expect(res.body.success).to.equal('true');
+          expect(res.body.data[0].message).to.equal('red-flag record has been deleted');
           done();
         });
     });


### PR DESCRIPTION
**What does this PR do?**
This is a pull request for the API endpoint to delete a red-flag record. 

**Description of Task to be completed?**
Have the following endpoint working and tested on postman:
`DELETE /api/v1/red-flags/<red-flag-id>`

**How should this be manually tested?**
- Clone the repo using git clone` https://github.com/fejiroofficial/iReporter.git.`
- run `git checkout ft-delete-redflag-162105836`
- run `npm install` and `npm start`.
- `to run the test: npm run test`
- `test using postman`
![screenshot 289](https://user-images.githubusercontent.com/38490848/48845607-3df64c00-ed9d-11e8-8213-0fe5710bf6ca.png)

**Relevant pivotal stories**
[162105836](https://www.pivotaltracker.com/n/projects/2226593/stories/162105836)