### PR TITLE
#162528248 update an intervention location

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -30,6 +30,7 @@ router.patch('/red-flags/:id([0-9]+)/comment', middlewares.validateUpdateComment
 router.patch('/interventions/:id([0-9]+)/comment', middlewares.validateUpdateComment, UpdateInterventionController.updateComment);
 
 router.patch('/red-flags/:id([0-9]+)/location', middlewares.validateUpdateLocation, UpdateRedFlagController.updateLocation);
+router.patch('/interventions/:id([0-9]+)/location', middlewares.validateUpdateLocation, UpdateInterventionController.updateLocation);
 
 router.use(ErrorController.routeError);
 

--- a/server/test/updateLocation.spec.js
+++ b/server/test/updateLocation.spec.js
@@ -6,7 +6,7 @@ import jwt from 'jsonwebtoken';
 chai.use(chaiHTTP);
 
 describe('/PATCH an incident location', () => {
-  describe('Updating location', () => {
+  describe('Updating red-flag location', () => {
     it('should throw an error if latitude is not provided', (done) => {
         const requestBody = {
           longitude: '3.1896830',
@@ -119,6 +119,120 @@ describe('/PATCH an incident location', () => {
             done();
           });
       });
+  })
 
+  describe('Updating intervention location', () => {
+    it('should throw an error if latitude is not provided', (done) => {
+        const requestBody = {
+          longitude: '3.1896830',
+        };
+        chai.request(app)
+          .patch('/api/v1/interventions/2/location')
+          .set('token', `${jwt.sign({ id: 1 }, 'fejiroofficial', { expiresIn: '24hrs' })}`)
+          .send(requestBody)
+          .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.success).to.equal('false');
+            expect(res.type).to.equal('application/json');
+            expect(res.body).to.be.an('object');
+            expect(res.body.message).to.equal('Please provide the location for this incident');
+            done();
+          });
+      });
+  
+      it('should throw an error if longitude is not provided', (done) => {
+        const requestBody = {
+          latitude: '6.4828617',
+        };
+        chai.request(app)
+          .patch('/api/v1/interventions/2/location')
+          .set('token', `${jwt.sign({ id: 1 }, 'fejiroofficial', { expiresIn: '24hrs' })}`)
+          .send(requestBody)
+          .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.success).to.equal('false');
+            expect(res.type).to.equal('application/json');
+            expect(res.body).to.be.an('object');
+            expect(res.body.message).to.equal('Please provide the location for this incident');
+            done();
+          });
+      });
+  
+      it('should throw an error if latitude is not a number', (done) => {
+        const requestBody = {
+          latitude: '6.4oh617',
+          longitude: '3.1896830',
+        };
+        chai.request(app)
+          .patch('/api/v1/interventions/2/location')
+          .set('token', `${jwt.sign({ id: 1 }, 'fejiroofficial', { expiresIn: '24hrs' })}`)
+          .send(requestBody)
+          .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.success).to.equal('false');
+            expect(res.type).to.equal('application/json');
+            expect(res.body).to.be.an('object');
+            expect(res.body.message).to.equal('latitude co-ordinate should be a number');
+            done();
+          });
+      });
+  
+      it('should throw an error if longitude is not a number', (done) => {
+        const requestBody = {
+          latitude: '6.434617',
+          longitude: '3.18gg830',
+        };
+        chai.request(app)
+          .patch('/api/v1/interventions/2/location')
+          .set('token', `${jwt.sign({ id: 1 }, 'fejiroofficial', { expiresIn: '24hrs' })}`)
+          .send(requestBody)
+          .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.success).to.equal('false');
+            expect(res.type).to.equal('application/json');
+            expect(res.body).to.be.an('object');
+            expect(res.body.message).to.equal('longitude co-ordinate should be a number');
+            done();
+          });
+      });
+
+      it('should throw an error if record is not an intervention', (done) => {
+        const requestBody = {
+          latitude: '6.434617',
+          longitude: '3.1844830',
+        };
+        chai.request(app)
+          .patch('/api/v1/interventions/3/location')
+          .set('token', `${jwt.sign({ id: 1 }, 'fejiroofficial', { expiresIn: '24hrs' })}`)
+          .send(requestBody)
+          .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.success).to.equal('false');
+            expect(res.type).to.equal('application/json');
+            expect(res.body).to.be.an('object');
+            expect(res.body.message).to.equal('This incident record is not an intervention');
+            done();
+          });
+      });
+
+      it('update should be successful', (done) => {
+        const requestBody = {
+          latitude: '6.434617',
+          longitude: '3.1844830',
+        };
+        chai.request(app)
+          .patch('/api/v1/interventions/2/location')
+          .set('token', `${jwt.sign({ id: 1 }, 'fejiroofficial', { expiresIn: '24hrs' })}`)
+          .send(requestBody)
+          .end((err, res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body.success).to.equal('true');
+            expect(res.type).to.equal('application/json');
+            expect(res.body).to.be.an('object');
+            expect(res.body.data[0].id).to.equal(2);
+            expect(res.body.data[0].message).to.equal('You have successfully updated the location of this intervention record');
+            done();
+          });
+      });
   })
 })    


### PR DESCRIPTION
**What does this PR do?**
This is a pull request for the API endpoint required to update the location of an intervention record. 

**Description of Task to be completed?**
Have the following endpoint working and tested on postman:
`PATCH /api/v1/interventions/<interventionId>/location`

**How should this be manually tested?**
- Clone the repo using git clone` https://github.com/fejiroofficial/iReporter.git.`
- run `git checkout ft-intervention-location-162528248`
- run `npm install` and `npm start`.
- `to run the test: npm run test`
- `test using postman`

**Relevant pivotal stories**
[162528248 ](https://www.pivotaltracker.com/n/projects/2226593/stories/162528248 )