### PR TITLE
#162472301 Delete a specific intervention record

### DIFF
--- a/server/controllers/intervention.js
+++ b/server/controllers/intervention.js
@@ -50,6 +50,59 @@ class InterventionController {
         });
       });
   }
+
+  /**
+  * @function deleteIntervention
+  * @memberof InterventionController
+  * @static
+  */
+  static deleteIntervention(req, res) {
+    const { userId } = req;
+    const interventionId = parseInt(req.params.id, 10);
+    return db.task('delete', db => db.incidents.findById(interventionId)
+      .then((record) => {
+        if (!record) {
+          return res.status(404).json({
+            status: 404,
+            success: 'false',
+            message: 'This record doesn\'t exist in the database',
+          });
+        }
+        if (record.type !== 'intervention') {
+          return res.status(400).json({
+            status: 400,
+            success: 'false',
+            message: 'This incident record is not an intervention',
+          });
+        }
+        const recordOwner = userId === record.createdby;
+        if (!recordOwner) {
+          return res.status(401).json({
+            status: 401,
+            success: 'false',
+            message: 'You are unauthorized to delete an information that was not posted by you',
+          });
+        }
+        return db.incidents.remove(interventionId)
+          .then(() => {
+            return res.status(200).json({
+              status: 200,
+              success: 'true',
+              data: [{
+                id: interventionId,
+                message: 'You have successfully deleted this intervention record',
+              }],
+            });
+          });
+      })
+      .catch((err) => {
+        return res.status(500).json({
+          success: 'false',
+          message: 'so sorry, something went wrong, try again',
+          err: err.message,
+        });
+      }));
+  }
 }
 
 export default InterventionController;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -26,6 +26,7 @@ router.post('/red-flags', middlewares.validatePostRedFlag, RedFlagController.pos
 router.post('/interventions', middlewares.validatePostRedFlag, InterventionController.postIntervention);
 
 router.delete('/red-flags/:id([0-9]+)', RedFlagController.deleteRedFlag);
+router.delete('/interventions/:id([0-9]+)', InterventionController.deleteIntervention);
 
 
 router.patch('/red-flags/:id([0-9]+)/comment', middlewares.validateUpdateComment, UpdateRedFlagController.updateComment);

--- a/server/test/index.spec.js
+++ b/server/test/index.spec.js
@@ -7,3 +7,4 @@ import './testFiles/postIntervention.spec';
 import './testFiles/updateComment.spec';
 import './testFiles/updateLocation.spec';
 import './testFiles/deleteRedflag.spec';
+import './testFiles/deleteIncident.spec';

--- a/server/test/testFiles/deleteIncident.spec.js
+++ b/server/test/testFiles/deleteIncident.spec.js
@@ -1,0 +1,64 @@
+import chai, { expect, request } from 'chai';
+import chaiHTTP from 'chai-http';
+import app from '../../app';
+import jwt from 'jsonwebtoken';
+
+chai.use(chaiHTTP);
+
+describe('/DELETE intervention', () => {
+  it('should throw an error if record does not exist', (done) => {
+    chai.request(app)
+      .delete('/api/v1/interventions/100')
+      .set('token', `${jwt.sign({ id: 1 }, 'fejiroofficial', { expiresIn: '24hrs' })}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(404);
+        expect(res.body.success).to.equal('false');
+        expect(res.type).to.equal('application/json');
+        expect(res.body).to.be.an('object');
+        expect(res.body.message).to.equal('This record doesn\'t exist in the database');
+        done();
+      });
+  });
+  it('should throw an error if record is not a intervention', (done) => {
+    chai.request(app)
+      .delete('/api/v1/interventions/3')
+      .set('token', `${jwt.sign({ id: 1 }, 'fejiroofficial', { expiresIn: '24hrs' })}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(400);
+        expect(res.body.success).to.equal('false');
+        expect(res.type).to.equal('application/json');
+        expect(res.body).to.be.an('object');
+        expect(res.body.message).to.equal('This incident record is not an intervention');
+        done();
+      });
+  });
+
+  it('should return 401 if record does not belong to who wants to delete it', (done) => {
+    chai
+      .request(app)
+      .delete('/api/v1/interventions/2')
+      .set('token', `${jwt.sign({ id: 2 }, process.env.SECRET_KEY, { expiresIn: '4hrs' })}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(401);
+        expect(res.body.success).to.equal('false');
+        expect(res.body.message).to.equal('You are unauthorized to delete an information that was not posted by you');
+        done();
+      });
+  });
+
+  it('should delete question if it exist and belongs to owner', (done) => {
+    chai
+      .request(app)
+      .delete('/api/v1/interventions/2')
+      .set('token', `${jwt.sign({ id: 1 }, process.env.SECRET_KEY, { expiresIn: '24hrs' })}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body.success).to.equal('true');
+        expect(res.type).to.equal('application/json');
+        expect(res.body).to.be.an('object');
+        expect(res.body.data[0].id).to.equal(2);
+        expect(res.body.data[0].message).to.equal('You have successfully deleted this intervention record');
+        done();
+      });
+  });
+})


### PR DESCRIPTION
**What does this PR do?**
This is a pull request for the API endpoint required to delete a specific intervention record. 

**Description of Task to be completed?**
Have the following endpoint working and tested on postman:
`DELETE /api/v1/interventions/<interventionId>/`

**How should this be manually tested?**
- Clone the repo using git clone` https://github.com/fejiroofficial/iReporter.git.`
- run `git checkout ft-delete-intervention-162472301`
- run `npm install` and `npm start`.
- `to run the test: npm run test`
- `test using postman`

**Relevant pivotal stories**
[162472301](https://www.pivotaltracker.com/n/projects/2226593/stories/162472301 )